### PR TITLE
Remove usage of unstable AtomicU64 / integer_atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blurmac"
 description = "Bluetooth Rust lib using macOS CoreBluetooth"
-version = "0.0.1"
+version = "0.1.0"
 readme = "README.md"
 keywords = ["bluetooth", "ble", "macOS", "CoreBluetooth"]
 repository = "https://github.com/akosthekiss/blurmac"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-#![feature(integer_atomics)]
-
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 use std::ffi::{CStr, CString};
-use std::sync::atomic::{AtomicU64, Ordering, ATOMIC_U64_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::time;
 use std::thread;
 
@@ -78,10 +78,10 @@ pub mod wait {
 
     pub type Timestamp = u64;
 
-    static TIMESTAMP: AtomicU64 = ATOMIC_U64_INIT;
+    static TIMESTAMP: AtomicUsize = ATOMIC_USIZE_INIT;
 
     pub fn get_timestamp() -> Timestamp {
-        TIMESTAMP.fetch_add(1, Ordering::SeqCst)
+        TIMESTAMP.fetch_add(1, Ordering::SeqCst) as u64
     }
 
     pub fn now() -> *mut Object {


### PR DESCRIPTION
Use AtomicUsize instead. Fix #1. It behaves the same, since macOS is always 64-bit these days.

Increment the version number to 0.1.0 rather than 0.0.2 so that it is possible next time to do version number changes that Cargo does not consider breaking.