### PR TITLE
Make this crate build on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os: osx
 
 language: rust
 rust:
+  - stable
   - nightly
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [dependencies]
+cocoa = "0.19.1"
 log = "0.3"
 objc = "0.2"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -26,7 +26,7 @@ unsafe impl Send for BluetoothAdapter {}
 unsafe impl Sync for BluetoothAdapter {}
 
 impl BluetoothAdapter {
-    pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
+    pub fn init() -> Result<BluetoothAdapter, Box<dyn Error>> {
         trace!("BluetoothAdapter::init");
         let delegate = bm::delegate();
         let manager = cb::centralmanager(delegate);
@@ -45,28 +45,28 @@ impl BluetoothAdapter {
         self.get_address().unwrap()
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_name");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let name = io::bluetoothhostcontroller_nameasstring(controller);
         Ok(nsx::string_to_string(name))
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_address");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let address = io::bluetoothhostcontroller_addressasstring(controller);
         Ok(nsx::string_to_string(address))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_class");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let device_class = io::bluetoothhostcontroller_classofdevice(controller);
         Ok(device_class)
     }
 
-    pub fn is_powered(&self) -> Result<bool, Box<Error>> {
+    pub fn is_powered(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothAdapter::is_powered");
         // NOTE: might be also available through
         // [[IOBluetoothHostController defaultController] powerState], but that's readonly, so keep
@@ -74,26 +74,26 @@ impl BluetoothAdapter {
         Ok(io::bluetoothpreferencegetcontrollerpowerstate() == 1)
     }
 
-    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_powered(&self, value: bool) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::set_powered");
         io::bluetoothpreferencesetcontrollerpowerstate(value as c_int);
         // TODO: wait for change to happen? whether it really happened?
         Ok(())
     }
 
-    pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discoverable(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothAdapter::is_discoverable");
         Ok(io::bluetoothpreferencegetdiscoverablestate() == 1)
     }
 
-    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::set_discoverable");
         io::bluetoothpreferencesetdiscoverablestate(value as c_int);
         // TODO: wait for change to happen? whether it really happened?
         Ok(())
     }
 
-    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_device_list(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_device_list");
         let mut v = vec!();
         let peripherals = bm::delegate_peripherals(self.delegate);
@@ -106,7 +106,7 @@ impl BluetoothAdapter {
 
     // Was in BluetoothDiscoverySession
 
-    fn start_discovery(&self) -> Result<(), Box<Error>> {
+    fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::start_discovery");
         let options = ns::mutabledictionary();
         // NOTE: If duplicates are not allowed then a peripheral will not show up again once
@@ -116,7 +116,7 @@ impl BluetoothAdapter {
         Ok(())
     }
 
-    fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::stop_discovery");
         cb::centralmanager_stopscan(self.manager);
         Ok(())
@@ -124,77 +124,77 @@ impl BluetoothAdapter {
 
     // Not supported
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_pairable(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothAdapter::is_pairable not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<Error>> {
+    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_pairable not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_pairable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_pairable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_discoverable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_discoverable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discovering(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothAdapter::is_discovering not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_uuids not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_vendor_id_source not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_vendor_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_product_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_device_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         warn!("BluetoothAdapter::get_modalias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -246,7 +246,7 @@ pub mod bm {
 pub mod bmx {
     use super::*;
 
-    pub fn peripheraldata(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<Error>> {
+    pub fn peripheraldata(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<dyn Error>> {
         let peripherals = bm::delegate_peripherals(delegate);
         let data = ns::dictionary_objectforkey(peripherals, ns::uuid_uuidstring(cb::peer_identifier(peripheral)));
         if data == nil {
@@ -256,7 +256,7 @@ pub mod bmx {
         Ok(data)
     }
 
-    pub fn peripheralevents(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<Error>> {
+    pub fn peripheralevents(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<dyn Error>> {
         let data = peripheraldata(delegate, peripheral)?;
         Ok(ns::dictionary_objectforkey(data, nsx::string_from_str(bm::PERIPHERALDATA_EVENTSKEY)))
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -57,7 +57,7 @@ impl BluetoothDevice {
         self.get_address().unwrap_or(String::new())
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothDevice::get_address");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -69,7 +69,7 @@ impl BluetoothDevice {
         Ok(uuid_string)
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothDevice::get_name");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -81,7 +81,7 @@ impl BluetoothDevice {
         Ok(name)
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothDevice::get_uuids");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -100,7 +100,7 @@ impl BluetoothDevice {
 
     }
 
-    pub fn connect(&self) -> Result<(), Box<Error>> {
+    pub fn connect(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDevice::connect");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -110,7 +110,7 @@ impl BluetoothDevice {
         Ok(())
     }
 
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDevice::disconnect");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -120,7 +120,7 @@ impl BluetoothDevice {
         Ok(())
     }
 
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connected(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothDevice::is_connected");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -131,7 +131,7 @@ impl BluetoothDevice {
         Ok(state == cb::PERIPHERALSTATE_CONNECTED)
     }
 
-    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothDevice::get_gatt_services");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -153,113 +153,113 @@ impl BluetoothDevice {
 
     // Not supported
 
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
+    pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_rssi not supported by BlurMac");
         // TODO: Now available from peripheral data in BluetoothAdapter.
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
+    pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_tx_power not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
         warn!("BluetoothDevice::get_manufacturer_data not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         warn!("BluetoothDevice::get_service_data not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
+    pub fn get_icon(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_icon not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_class not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
+    pub fn get_appearance(&self) -> Result<u16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_appearance not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
+    pub fn is_paired(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_paired not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
+    pub fn is_trusted(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_trusted not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
+    pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_blocked not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::set_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_legacy_pairing not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_vendor_id_source not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_vendor_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_product_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_device_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         warn!("BluetoothDevice::get_modalias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::connect_profile not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::disconnect_profile not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::pair not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::cancel_pairing not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }

--- a/src/discovery_session.rs
+++ b/src/discovery_session.rs
@@ -17,20 +17,20 @@ pub struct BluetoothDiscoverySession {
 }
 
 impl BluetoothDiscoverySession {
-    pub fn create_session(_adapter: Arc<BluetoothAdapter>) -> Result<BluetoothDiscoverySession, Box<Error>> {
+    pub fn create_session(_adapter: Arc<BluetoothAdapter>) -> Result<BluetoothDiscoverySession, Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::create_session");
         Ok(BluetoothDiscoverySession {
             // adapter: adapter.clone()
         })
     }
 
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::start_discovery");
         // NOTE: discovery is started by BluetoothAdapter::new to allow devices to pop up
         Ok(())
     }
 
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::stop_discovery");
         // NOTE: discovery is only stopped when BluetoothAdapter is dropped
         Ok(())

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -108,13 +108,13 @@ pub mod ns {
 
     pub fn mutabledictionary_removeobjectforkey(nsmutdict: *mut Object, key: *mut Object) {
         unsafe {
-            msg_send![nsmutdict, removeObjectForKey:key];
+            let _: () = msg_send![nsmutdict, removeObjectForKey:key];
         }
     }
 
     pub fn mutabledictionary_setobject_forkey(nsmutdict: *mut Object, object: *mut Object, key: *mut Object) {
         unsafe {
-            msg_send![nsmutdict, setObject:object forKey:key];
+            let _: () = msg_send![nsmutdict, setObject:object forKey:key];
         }
     }
 
@@ -241,32 +241,32 @@ pub mod cb {
     pub fn centralmanager(delegate: *mut Object /*CBCentralManagerDelegate* */) -> *mut Object /*CBCentralManager* */ {
         unsafe {
             let cbcentralmanager: *mut Object = msg_send![Class::get("CBCentralManager").unwrap(), alloc];
-            msg_send![cbcentralmanager, initWithDelegate:delegate queue:nil];
+            let _: () = msg_send![cbcentralmanager, initWithDelegate:delegate queue:nil];
             cbcentralmanager
         }
     }
 
     pub fn centralmanager_scanforperipherals_options(cbcentralmanager: *mut Object, options: *mut Object /* NSDictionary<NSString*,id> */) {
         unsafe {
-            msg_send![cbcentralmanager, scanForPeripheralsWithServices:nil options:options];
+            let _: () = msg_send![cbcentralmanager, scanForPeripheralsWithServices:nil options:options];
         }
     }
 
     pub fn centralmanager_stopscan(cbcentralmanager: *mut Object) {
         unsafe {
-            msg_send![cbcentralmanager, stopScan];
+            let _: () = msg_send![cbcentralmanager, stopScan];
         }
     }
 
     pub fn centralmanager_connectperipheral(cbcentralmanager: *mut Object, peripheral: *mut Object /* CBPeripheral* */) {
         unsafe {
-            msg_send![cbcentralmanager, connectPeripheral:peripheral options:nil];
+            let _: () = msg_send![cbcentralmanager, connectPeripheral:peripheral options:nil];
         }
     }
 
     pub fn centralmanager_cancelperipheralconnection(cbcentralmanager: *mut Object, peripheral: *mut Object /* CBPeripheral* */) {
         unsafe {
-            msg_send![cbcentralmanager, cancelPeripheralConnection:peripheral];
+            let _: () = msg_send![cbcentralmanager, cancelPeripheralConnection:peripheral];
         }
     }
 
@@ -297,19 +297,19 @@ pub mod cb {
 
     pub fn peripheral_setdelegate(cbperipheral: *mut Object, delegate: *mut Object /* CBPeripheralDelegate* */) {
         unsafe {
-            msg_send![cbperipheral, setDelegate:delegate];
+            let _: () = msg_send![cbperipheral, setDelegate:delegate];
         }
     }
 
     pub fn peripheral_discoverservices(cbperipheral: *mut Object) {
         unsafe {
-            msg_send![cbperipheral, discoverServices:nil];
+            let _: () = msg_send![cbperipheral, discoverServices:nil];
         }
     }
 
     pub fn peripheral_discoverincludedservicesforservice(cbperipheral: *mut Object, service: *mut Object /* CBService* */) {
         unsafe {
-            msg_send![cbperipheral, discoverIncludedServices:nil forService:service];
+            let _: () = msg_send![cbperipheral, discoverIncludedServices:nil forService:service];
         }
     }
 
@@ -322,31 +322,31 @@ pub mod cb {
 
     pub fn peripheral_discovercharacteristicsforservice(cbperipheral: *mut Object, service: *mut Object /* CBService* */) {
         unsafe {
-            msg_send![cbperipheral, discoverCharacteristics:nil forService:service];
+            let _: () = msg_send![cbperipheral, discoverCharacteristics:nil forService:service];
         }
     }
 
     pub fn peripheral_readvalueforcharacteristic(cbperipheral: *mut Object, characteristic: *mut Object /* CBCharacteristic* */) {
         unsafe {
-            msg_send![cbperipheral, readValueForCharacteristic:characteristic];
+            let _: () = msg_send![cbperipheral, readValueForCharacteristic:characteristic];
         }
     }
 
     pub fn peripheral_writevalue_forcharacteristic(cbperipheral: *mut Object, value: *mut Object /* NSData* */, characteristic: *mut Object /* CBCharacteristic* */) {
         unsafe {
-            msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:0]; // CBCharacteristicWriteWithResponse from CBPeripheral.h
+            let _: () = msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:0]; // CBCharacteristicWriteWithResponse from CBPeripheral.h
         }
     }
 
     pub fn peripheral_setnotifyvalue_forcharacteristic(cbperipheral: *mut Object, value: BOOL, characteristic: *mut Object /* CBCharacteristic* */) {
         unsafe {
-            msg_send![cbperipheral, setNotifyValue:value forCharacteristic:characteristic];
+            let _: () = msg_send![cbperipheral, setNotifyValue:value forCharacteristic:characteristic];
         }
     }
 
     pub fn peripheral_discoverdescriptorsforcharacteristic(cbperipheral: *mut Object, characteristic: *mut Object /* CBCharacteristic* */) {
         unsafe {
-            msg_send![cbperipheral, discoverDescriptorsForCharacteristic:characteristic];
+            let _: () = msg_send![cbperipheral, discoverDescriptorsForCharacteristic:characteristic];
         }
     }
 

--- a/src/gatt_characteristic.rs
+++ b/src/gatt_characteristic.rs
@@ -57,7 +57,7 @@ impl BluetoothGATTCharacteristic {
         self.get_uuid().unwrap_or(String::new())
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_uuid");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -68,7 +68,7 @@ impl BluetoothGATTCharacteristic {
         Ok(uuid_string)
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -86,7 +86,7 @@ impl BluetoothGATTCharacteristic {
         Ok(v)
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::read_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -106,7 +106,7 @@ impl BluetoothGATTCharacteristic {
         self.get_value()
     }
 
-    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::write_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -126,7 +126,7 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
+    pub fn is_notifying(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::is_notifying");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -137,7 +137,7 @@ impl BluetoothGATTCharacteristic {
         Ok(notifying != NO)
     }
 
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+    pub fn start_notify(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::start_notify");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -147,7 +147,7 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+    pub fn stop_notify(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::stop_notify");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -157,12 +157,12 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<dyn Error>> {
         warn!("BluetoothGATTCharacteristic::get_gatt_descriptors");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_flags");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));

--- a/src/gatt_descriptor.rs
+++ b/src/gatt_descriptor.rs
@@ -22,23 +22,23 @@ impl BluetoothGATTDescriptor {
         String::new()
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }

--- a/src/gatt_service.rs
+++ b/src/gatt_service.rs
@@ -58,7 +58,7 @@ impl BluetoothGATTService {
         self.get_uuid().unwrap_or(String::new())
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_uuid");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -69,7 +69,7 @@ impl BluetoothGATTService {
         Ok(uuid_string)
     }
 
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
+    pub fn is_primary(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothGATTService::is_primary");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -82,7 +82,7 @@ impl BluetoothGATTService {
         Ok(true)
     }
 
-    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_includes(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_includes");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -100,7 +100,7 @@ impl BluetoothGATTService {
         Ok(v)
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_gatt_characteristics");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-#![feature(integer_atomics)]
-
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
+extern crate cocoa;
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 use std::ffi::{CStr, CString};
-use std::sync::atomic::{AtomicU64, Ordering, ATOMIC_U64_INIT};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time;
 use std::thread;
 
@@ -78,7 +78,7 @@ pub mod wait {
 
     pub type Timestamp = u64;
 
-    static TIMESTAMP: AtomicU64 = ATOMIC_U64_INIT;
+    static TIMESTAMP: AtomicU64 = AtomicU64::new(0);
 
     pub fn get_timestamp() -> Timestamp {
         TIMESTAMP.fetch_add(1, Ordering::SeqCst)
@@ -88,7 +88,7 @@ pub mod wait {
         ns::number_withunsignedlonglong(get_timestamp())
     }
 
-    pub fn wait_or_timeout<F>(mut f: F) -> Result<(), Box<Error>>
+    pub fn wait_or_timeout<F>(mut f: F) -> Result<(), Box<dyn Error>>
         where F: FnMut() -> bool {
 
         let now = time::Instant::now();


### PR DESCRIPTION
This involves three simple changes:
* Remove #![feature(integer_atomics)] since this feature is now stable.
* Replace usage of ATOMIC_U64_INIT with AtomicU64::new(0)
* Replace Box<Error> with Box<dyn Error> to silence warnings

Additionally I changed the Travis CI configuration to build against stable
as well as nightly.